### PR TITLE
Feat/merchant invoice revenue

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -5,4 +5,14 @@ class Invoice < ApplicationRecord
   belongs_to :customer
 
   enum status:["in progress", "completed", "cancelled"]
+
+  def total_revenue
+    helpers.number_to_currency((self.invoice_items.sum(:unit_price).to_f)/100)
+  end
+
+private
+# Helper Methods
+  def helpers
+  ActionController::Base.helpers
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -5,4 +5,14 @@ class InvoiceItem < ApplicationRecord
   validates_numericality_of :quantity
   validates_numericality_of :unit_price
   enum status:["pending", "packaged", "shipped"]
+
+  def unit_price_converted
+    helpers.number_to_currency(self.unit_price.to_f/100)
+  end
+
+private
+  # Helper Methods
+  def helpers
+  ActionController::Base.helpers
+  end
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -22,6 +22,7 @@
     <h2><%= "Invoice: #{@invoice.id}"%> </h2>
     <p><%= "Status: #{@invoice.status}" %> </p>
     <p><%= "Created on: #{@invoice.created_at.strftime("%A, %B %d, %Y")}" %></p>
+    <p><%= "Total Revenue: #{@invoice.total_revenue}" %></p>
     <h2>Customer</h2>
     <p> <%= "#{@invoice.customer.first_name} #{@invoice.customer.last_name}" %></p>
   </div>
@@ -40,7 +41,7 @@
         <tr>
           <td> <%= invoice_item.item.name %></td>
           <td> <%= invoice_item.status %>
-          <td> <%= invoice_item.item.unit_price %></td>
+          <td> <%= invoice_item.unit_price %></td>
           <td> <%= invoice_item.quantity %></td>
         </tr>
       <% end %>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -41,7 +41,7 @@
         <tr>
           <td> <%= invoice_item.item.name %></td>
           <td> <%= invoice_item.status %>
-          <td> <%= invoice_item.unit_price %></td>
+          <td> <%= invoice_item.unit_price_converted %></td>
           <td> <%= invoice_item.quantity %></td>
         </tr>
       <% end %>

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -61,10 +61,9 @@ RSpec.describe 'Merchant_Invoices Show Page', type: :feature do
         expect(page).to have_content(@items[0].name)
         expect(page).to_not have_content(@items[3].name)
         expect(page).to have_content(invoice_item1.quantity)
-        expect(page).to have_content(invoice_item1.unit_price)
-        expect(page).to_not have_content(invoice_item2.unit_price)
+        expect(page).to have_content(invoice_item1.unit_price_converted)
+        expect(page).to_not have_content(invoice_item2.unit_price_converted)
         expect(page).to have_content(invoice_item1.status)
-
       end
     end
   end

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe 'Merchant_Invoices Show Page', type: :feature do
         expect(page).to have_content(@items[0].name)
         expect(page).to_not have_content(@items[3].name)
         expect(page).to have_content(invoice_item1.quantity)
-        expect(page).to have_content(@items[0].unit_price)
-        expect(page).to_not have_content(@items[3].unit_price)
+        expect(page).to have_content(invoice_item1.unit_price)
+        expect(page).to_not have_content(invoice_item2.unit_price)
         expect(page).to have_content(invoice_item1.status)
 
       end

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -48,16 +48,7 @@ RSpec.describe 'Merchant_Invoices Show Page', type: :feature do
       expect(page).to_not have_content("#{customers[1].first_name} #{customers[1].last_name}")
     end
   end
-  # Merchant Invoice Show Page: Invoice Item Information
 
-# As a merchant
-# When I visit my merchant invoice show page
-# Then I see all of my items on the invoice including:
-# - Item name
-# - The quantity of the item ordered
-# - The price the Item sold for
-# - The Invoice Item status
-# And I do not see any information related to Items for other merchants
   describe 'Merchant_Invoices User Story 3' do
     it 'can display items attributes that belongs to an invoice' do
       visit "/merchants/#{merchants[0].id}/invoices/#{@invoices[0].id}"
@@ -75,6 +66,14 @@ RSpec.describe 'Merchant_Invoices Show Page', type: :feature do
         expect(page).to have_content(invoice_item1.status)
 
       end
+    end
+  end
+
+  describe "User Story 4 - Merchant Invoice Show Page: Total Revenue" do
+    it "shows the total revenue of all items on the invoice" do
+      visit "/merchants/#{merchants[0].id}/invoices/#{@invoices[0].id}"
+
+      expect(page).to have_content("Total Revenue: #{@invoices[0].total_revenue}")
     end
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -11,4 +11,24 @@ RSpec.describe InvoiceItem, type: :model do
     it { should validate_numericality_of :unit_price}
     it { should define_enum_for(:status).with_values(["pending", "packaged", "shipped"])}
   end
+
+  let!(:merchant1) { create(:merchant) }
+
+  let!(:item1) { create(:item, merchant: merchant1) }
+  let!(:item2) { create(:item, merchant: merchant1) }
+
+  let!(:customer1) { create(:customer) }
+
+  let!(:invoice1) { create(:invoice, customer: customer1) }
+
+  let!(:transaction1) { create(:transaction, invoice: invoice1, result: 1) }
+
+  let!(:invoice_item1) { create(:invoice_item, item: item1, invoice: invoice1, unit_price: 3011) }
+  let!(:invoice_item2) { create(:invoice_item, item: item2, invoice: invoice1, unit_price: 2524) }
+
+  describe "#instance methods" do
+    it "#unit_price_converted shows unit price as a currency format" do
+      expect(invoice_item1.unit_price_converted).to eq("$30.11")
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -11,4 +11,24 @@ RSpec.describe Invoice, type: :model do
   describe 'validations' do
     it { should define_enum_for(:status).with_values(["in progress", "completed", "cancelled"])}
   end
+
+  let!(:merchant1) { create(:merchant) }
+
+  let!(:item1) { create(:item, merchant: merchant1) }
+  let!(:item2) { create(:item, merchant: merchant1) }
+
+  let!(:customer1) { create(:customer) }
+
+  let!(:invoice1) { create(:invoice, customer: customer1) }
+
+  let!(:transaction1) { create(:transaction, invoice: invoice1, result: 1) }
+
+  let!(:invoice_item1) { create(:invoice_item, item: item1, invoice: invoice1, unit_price: 3011) }
+  let!(:invoice_item2) { create(:invoice_item, item: item2, invoice: invoice1, unit_price: 2524) }
+
+  describe "#instance methods" do
+    it "#total_revenue returns total revenue of an invoice" do
+      expect(invoice1.total_revenue).to eq(5535)
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Invoice, type: :model do
 
   describe "#instance methods" do
     it "#total_revenue returns total revenue of an invoice" do
-      expect(invoice1.total_revenue).to eq(5535)
+      expect(invoice1.total_revenue).to eq("$55.35")
     end
   end
 end


### PR DESCRIPTION
This PR completes User Story 4 and adds some helper methods to our Invoice and InvoiceItems classes so we can call "number_to_currency".
Added methods for Invoice#total_revenue and InvoiceItem#unit_price_converted